### PR TITLE
minor fix image dumping

### DIFF
--- a/run_inference.py
+++ b/run_inference.py
@@ -67,16 +67,16 @@ def main():
 
         output = disp_net(tensor_img)[0]
 
-        file_ = file.replace(args.dataset_dir, '')
-        file_ = '-'.join(file_.split('/'))
+        file_path, file_ext = file.relpath(args.dataset_dir).splitext()
+        file_name = '-'.join(file_path.splitall())
                                      
         if args.output_disp:
             disp = (255*tensor2array(output, max_value=None, colormap='bone', channel_first=False)).astype(np.uint8)
-            imsave(output_dir/'{}_disp{}'.format(file_,file.ext), np.transpose(disp, (1,2,0)))
+            imsave(output_dir/'{}_disp{}'.format(file_name, file_ext), np.transpose(disp, (1,2,0)))
         if args.output_depth:
             depth = 1/output
             depth = (255*tensor2array(depth, max_value=10, colormap='rainbow', channel_first=False)).astype(np.uint8)
-            imsave(output_dir/'{}_depth{}'.format(file_,file.ext), np.transpose(depth, (1,2,0)))
+            imsave(output_dir/'{}_depth{}'.format(file_name, file_ext), np.transpose(depth, (1,2,0)))
 
 
 if __name__ == '__main__':

--- a/run_inference.py
+++ b/run_inference.py
@@ -67,13 +67,16 @@ def main():
 
         output = disp_net(tensor_img)[0]
 
+        file_ = file.replace(args.dataset_dir, '')
+        file_ = '-'.join(file_.split('/'))
+                                     
         if args.output_disp:
             disp = (255*tensor2array(output, max_value=None, colormap='bone', channel_first=False)).astype(np.uint8)
-            imsave(output_dir/'{}_disp{}'.format(file.namebase,file.ext), disp)
+            imsave(output_dir/'{}_disp{}'.format(file_,file.ext), np.transpose(disp, (1,2,0)))
         if args.output_depth:
             depth = 1/output
             depth = (255*tensor2array(depth, max_value=10, colormap='rainbow', channel_first=False)).astype(np.uint8)
-            imsave(output_dir/'{}_depth{}'.format(file.namebase,file.ext), depth)
+            imsave(output_dir/'{}_depth{}'.format(file_,file.ext), np.transpose(depth, (1,2,0)))
 
 
 if __name__ == '__main__':

--- a/run_inference.py
+++ b/run_inference.py
@@ -71,11 +71,11 @@ def main():
         file_name = '-'.join(file_path.splitall())
                                      
         if args.output_disp:
-            disp = (255*tensor2array(output, max_value=None, colormap='bone', channel_first=False)).astype(np.uint8)
+            disp = (255*tensor2array(output, max_value=None, colormap='bone')).astype(np.uint8)
             imsave(output_dir/'{}_disp{}'.format(file_name, file_ext), np.transpose(disp, (1,2,0)))
         if args.output_depth:
             depth = 1/output
-            depth = (255*tensor2array(depth, max_value=10, colormap='rainbow', channel_first=False)).astype(np.uint8)
+            depth = (255*tensor2array(depth, max_value=10, colormap='rainbow')).astype(np.uint8)
             imsave(output_dir/'{}_depth{}'.format(file_name, file_ext), np.transpose(depth, (1,2,0)))
 
 


### PR DESCRIPTION
In the test images of eigen split there are images with the same namebase (e.g. below) which would lead to overwriting each other when dumping disp/depth images,
```
2011_09_26/2011_09_26_drive_0048_sync/image_02/data/0000000002.png
2011_09_26/2011_09_26_drive_0052_sync/image_02/data/0000000002.png
...
```
also the disp/depth images before dumping seems to be of shape ```(C, H, W)```, therefore transposing them into ```(H, W, C)``` to avoid error when using ```imsave```.

Thank you for this awesome work!