### PR TITLE
Add pebble to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ blessings
 progressbar2
 tqdm
 path
+pebble


### PR DESCRIPTION
pebble is a required python module but isn't included in requirements.txt. This commit adds it