### PR TITLE
Fix run_inference.py resizing

### DIFF
--- a/run_inference.py
+++ b/run_inference.py
@@ -59,7 +59,7 @@ def main():
 
         h,w,_ = img.shape
         if (not args.no_resize) and (h != args.img_height or w != args.img_width):
-            img = np.array(Image.fromarray(img).imresize((args.img_height, args.img_width)))
+            img = np.array(Image.fromarray(img).imresize((args.img_width, args.img_height)))
         img = np.transpose(img, (2, 0, 1))
 
         tensor_img = torch.from_numpy(img.astype(np.float32)).unsqueeze(0)


### PR DESCRIPTION
PIL image resize expects (width, height) not (height, width)

https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.resize