### PR TITLE
Replacing Deprecated Imports from scipy.misc

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ pebble
 matplotlib
 imageio
 scipy
+scikit-image
 argparse
 tensorboardX
 blessings
@@ -51,7 +52,7 @@ If you don't have an up to date pytorch, the tags can help you checkout the righ
 * In addition you don't need to prepare data for a particular sequence length anymore as stacking is made on the fly.
 * You can still choose the former stacked frames dataset format.
 * Convergence is now almost as good as original paper with same hyper parameters
-* You can know compare with groud truth for your validation set. It is still possible to validate without, but you now can see that minimizing photometric error is not equivalent to optimizing depth map.
+* You can know compare with ground truth for your validation set. It is still possible to validate without, but you now can see that minimizing photometric error is not equivalent to optimizing depth map.
 
 ### Differences with official Implementation
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Preparation is roughly the same command as in the original code.
 
 For [KITTI](http://www.cvlibs.net/datasets/kitti/raw_data.php), first download the dataset using this [script](http://www.cvlibs.net/download.php?file=raw_data_downloader.zip) provided on the official website, and then run the following command. The `--with-depth` option will save resized copies of groundtruth to help you setting hyper parameters. The `--with-pose` will dump the sequence pose in the same format as Odometry dataset (see pose evaluation)
 ```bash
-python3 data/prepare_train_data.py /path/to/raw/kitti/dataset/ --dataset-format 'kitti' --dump-root /path/to/resulting/formatted/data/ --width 416 --height 128 --num-threads 4 [--static-frames /path/to/static_frames.txt] [--with-depth] [--with-pose]
+python3 data/prepare_train_data.py /path/to/raw/kitti/dataset/ --dataset-format 'kitti_raw' --dump-root /path/to/resulting/formatted/data/ --width 416 --height 128 --num-threads 4 [--static-frames /path/to/static_frames.txt] [--with-depth] [--with-pose]
 ```
 
 

--- a/data/prepare_train_data.py
+++ b/data/prepare_train_data.py
@@ -8,7 +8,7 @@ from imageio import imwrite
 parser = argparse.ArgumentParser()
 parser.add_argument("dataset_dir", metavar='DIR', type=Path,
                     help='path to original dataset')
-parser.add_argument("--dataset-format", type=str, default='kitti', choices=["kitti_raw", "kitti_odometry", "cityscapes"])
+parser.add_argument("--dataset-format", type=str, default='kitti_raw', choices=["kitti_raw", "kitti_odometry", "cityscapes"])
 parser.add_argument("--static-frames", default=None, type=Path,
                     help="list of imgs to discard for being static, if not set will discard them based on speed \
                     (careful, on KITTI some frames have incorrect speed)")

--- a/kitti_eval/depth_evaluation_utils.py
+++ b/kitti_eval/depth_evaluation_utils.py
@@ -3,7 +3,7 @@
 import numpy as np
 from collections import Counter
 from path import Path
-from scipy.misc import imread
+from imageio import imread
 from tqdm import tqdm
 import datetime
 

--- a/kitti_eval/pose_evaluation_utils.py
+++ b/kitti_eval/pose_evaluation_utils.py
@@ -17,7 +17,7 @@ class test_framework_KITTI(object):
             for snippet_indices in sample_list:
                 imgs = [imread(img_list[i]).astype(np.float32) for i in snippet_indices]
 
-                poses = np.stack(pose_list[i] for i in snippet_indices)
+                poses = np.stack([pose_list[i] for i in snippet_indices])
                 first_pose = poses[0]
                 poses[:,:,-1] -= first_pose[:,-1]
                 compensated_poses = np.linalg.inv(first_pose[:,:3]) @ poses

--- a/kitti_eval/pose_evaluation_utils.py
+++ b/kitti_eval/pose_evaluation_utils.py
@@ -3,7 +3,7 @@
 import numpy as np
 # import pandas as pd
 from path import Path
-from scipy.misc import imread
+from imageio import imread
 from tqdm import tqdm
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ torch >= 1.4.0
 imageio
 matplotlib
 scipy
+scikit-image
 argparse
 tensorboardX
 blessings

--- a/stillbox_eval/depth_evaluation_utils.py
+++ b/stillbox_eval/depth_evaluation_utils.py
@@ -1,7 +1,7 @@
 import numpy as np
 import json
 from path import Path
-from scipy.misc import imread
+from imageio import imread
 from tqdm import tqdm
 
 

--- a/test_disp.py
+++ b/test_disp.py
@@ -1,6 +1,6 @@
 import torch
 
-from scipy.misc import imresize
+from skimage.transform import resize as imresize
 from scipy.ndimage.interpolation import zoom
 import numpy as np
 from path import Path

--- a/test_disp.py
+++ b/test_disp.py
@@ -1,7 +1,7 @@
 import torch
 
 from skimage.transform import resize as imresize
-from scipy.ndimage.interpolation import zoom
+from scipy.ndimage import zoom
 import numpy as np
 from path import Path
 import argparse

--- a/test_pose.py
+++ b/test_pose.py
@@ -1,7 +1,7 @@
 import torch
 from torch.autograd import Variable
 
-from scipy.misc import imresize
+from skimage.transform import resize as imresize
 import numpy as np
 from path import Path
 import argparse


### PR DESCRIPTION
### PR Motivation
* scipy.misc.imresize has been [deprecated](https://docs.scipy.org/doc/scipy-1.2.1/reference/generated/scipy.misc.imresize.html)
* scipy.misc.imread has also been [deprecated](https://docs.scipy.org/doc/scipy-1.2.1/reference/generated/scipy.misc.imread.html)
* Warnings on using np.stack() without brackets.
* Minor textual updates to README, requirements.txt and argparser defaults.
* Addresses issues raised by #134 

### Changes
This PR replaces all import of ```scipy.misc.imresize``` with ```from skimage.transform import resize as imresize``` and all imports of ```scipy.misc.imread``` with``` from imageio import imread```.

It fixes a minor typo in the README ```groud -> ground``` as well as updates the requirements.txt to add the new import dependency (```scikit-image```). I've also updated the argparser in *data/prepare_train_data.py* to a default ```dataset_format``` of ```kitti_raw``` as the prior default was not an acceptable choice (```kitti``` when the allowed choices were ```choices=["kitti_raw", "kitti_odometry", "cityscapes"]```).

### Results
The results were validated with Python 3.8 and 3.9 and seemed to be approximately equivalent to the repo reported results.

**Pose Results**

|      Sequence     |          ATE         |          RE          |
|:-----------------:|:--------------------:|:--------------------:|
| 09 (Pull Request) | 0.0195 (std 0.0107)  | 0.0041 (std 0.0022)  |
| 09 (Repo Results) | 0.0179 (std. 0.0110) | 0.0018 (std. 0.0009) |
| 10 (Pull Request) | 0.0148 (std 0.0096)  | 0.0042 (std 0.0027)  |
| 10 (Repo Results) | 0.0141 (std 0.0115)  | 0.0018 (std 0.0011)  |

**Depth Results**

|              | Abs Rel | Sq Rel  | RMSE  | RMSE (log) | Acc. 1 | Acc. 2 | Acc. 3 |
|--------------|---------|---------|-------|------------|--------|--------|--------|
| Pull Request | 0.181 | 1.340 | 6.222 | 0.261      | 0.733 | 0.908  | 0.964  |
| Repo Results | 0.181   | 1.341   | 6.236 | 0.262      | 0.733  | 0.901  | 0.964  |
